### PR TITLE
Added accept action and metabox functionality

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -155,6 +155,53 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         });
     }
+
+    if( 'woocommerce_page_woo-under-review' === pagenow ){
+        const reviewaction = document.querySelectorAll('.review-action');
+        console.log(ajax_object);
+         // Attach click event listener to all date elements.
+         reviewaction.forEach(dateElement => {
+            dateElement.addEventListener('click', async (e) => {
+                const id = e.target.getAttribute('data-id');
+                const targetElement = e.target;
+                targetElement.setAttribute('disabled', true);
+                const value = await swal({
+                    title: "Under review order.",
+                    text: "Remove under review order from list.",
+                    buttons: true,
+                    dangerMode: false,
+                });
+
+                // Proceed if the value is valid.
+                if (value) {
+                    try {
+                        // Send the AJAX request using fetch.
+                        const response = await fetch(ajaxurl, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                            },
+                            body: new URLSearchParams({
+                                action: 'change_order_metaupdate',
+                                orderid: id,
+                                _ajax_nonce: changedate.nonce
+                            })
+                        });
+                        const data = await response.json();
+                        // Check if update was successfull.
+                        if (data.success) {
+                            console.log(data);
+                            targetElement.setAttribute('disabled', true);
+                        }else {
+                            console.log(data);
+                        }
+                    } catch (error) {
+                        console.error('AJAX request failed:', error);
+                    }
+                }
+            });
+        });
+    }
     
     // Loop through each element and toggle the 'hidden' class.
     elements.forEach(element => {

--- a/includes/admin/class-weightreport-editing-order.php
+++ b/includes/admin/class-weightreport-editing-order.php
@@ -34,9 +34,49 @@ class WeightReport_Editing_Order {
 	public function __construct() {
 		// Add admin actions only for users with 'manage_options' capability.
 		if ( current_user_can( 'manage_options' ) ) {
+			add_action( 'add_meta_boxes', array( $this, 'weightreport_add_under_review_meta_box' ) );
 			add_action( 'admin_notices', array( $this, 'add_custom_notice_and_button' ) );
 			add_action( 'wp_ajax_handle_custom_admin_action', array( $this, 'handle_custom_admin_action' ) );
 		}
+	}
+
+	/**
+	 * Adds the Test Order meta box to WooCommerce order edit pages.
+	 *
+	 * @since 1.0.0
+	 */
+	public function weightreport_add_under_review_meta_box() {
+		add_meta_box(
+			'weightreport_under_review_meta_box',
+			__( 'Under Review', 'woo-weight-report' ),
+			array( $this, 'weightreport_under_review_meta_box_callback' ),
+			'shop_order',
+			'side',
+			'high'
+		);
+	}
+
+
+	/**
+	 * Callback function for displaying the Test Order meta box.
+	 *
+	 * Displays a checkbox allowing admins to mark the order as a test order.
+	 *
+	 * @param WP_Post $post The post object for the current WooCommerce order.
+	 */
+	public function weightreport_under_review_meta_box_callback( $post ) {
+		$is_under_review = get_post_meta( $post->ID, '_status_under_review', true );
+		?>
+		<label for="order_checkbox">
+			<input type="checkbox" id="order_checkbox" name="review_status" value="<?php echo esc_attr( $is_under_review ); ?>" <?php checked( $is_under_review, 'yes' ); ?> />
+			<?php
+			esc_html_e( 'This order is a under review.', 'woo-weight-report' );
+			?>
+		</label>
+		<p>
+		<?php
+		submit_button( __( 'Submit', 'woo-weight-report' ), 'primary', 'submit-form', false );
+		echo '</p>';
 	}
 
 	/**


### PR DESCRIPTION
*Added accept action and meta box functionality*
- Implemented accept action in the under-review table settings
- The meta box on the order page is used to manually set orders as they are under review.
- Updating the first-time order on the order page sets the order as under review. 
